### PR TITLE
fixed style bug from alert dialog

### DIFF
--- a/apps/docs/pages/docs/components/AlertDialog.mdx
+++ b/apps/docs/pages/docs/components/AlertDialog.mdx
@@ -17,24 +17,27 @@ import { InfoCircledIcon } from "@radix-ui/react-icons";
   <Showcase.Preview>
     <AlertDialog.Root>
       <AlertDialog.Trigger asChild>
-        <Button variant="destructive">Delete Account</Button>
+        <Button variant='destructive'>Delete Account</Button>
       </AlertDialog.Trigger>
       <AlertDialog.Portal>
-        <AlertDialog.Overlay className="AlertDialogOverlay" />
-        <AlertDialog.Content className="AlertDialogContent">
-          <AlertDialog.Title className="AlertDialogTitle">
+        <AlertDialog.Overlay className='AlertDialogOverlay' />
+        <AlertDialog.Content className='AlertDialogContent'>
+          <AlertDialog.Title className='AlertDialogTitle'>
             Are you absolutely sure?
           </AlertDialog.Title>
-          <AlertDialog.Description className="AlertDialogDescription">
+          <AlertDialog.Description className='AlertDialogDescription'>
             This action cannot be undone. This will permanently delete your
             account and remove your data from our servers.
           </AlertDialog.Description>
-          <div style={{ display: "flex", gap: 25, justifyContent: "flex-end" }}>
+          <div
+            className='mt-2'
+            style={{ display: "flex", gap: 25, justifyContent: "flex-end" }}
+          >
             <AlertDialog.Cancel asChild>
-              <button className="Button mauve">Cancel</button>
+              <button className='Button mauve'>Cancel</button>
             </AlertDialog.Cancel>
             <AlertDialog.Action asChild>
-              <button className="Button red">Yes, delete account</button>
+              <button className='Button red'>Yes, delete account</button>
             </AlertDialog.Action>
           </div>
         </AlertDialog.Content>

--- a/packages/components/src/AlertDialog.tsx
+++ b/packages/components/src/AlertDialog.tsx
@@ -24,7 +24,7 @@ const Portal = ({
   ...props
 }: AlertDialogPrimitive.AlertDialogPortalProps) => (
   <AlertDialogPrimitive.Portal className={cn(className)} {...props}>
-    <div className="fixed inset-0 z-50 flex items-end justify-center sm:items-center">
+    <div className='fixed inset-0 z-50 flex items-end justify-center sm:items-center'>
       {children}
     </div>
   </AlertDialogPrimitive.Portal>
@@ -178,7 +178,7 @@ const Cancel = React.forwardRef<
   <AlertDialogPrimitive.Cancel
     ref={ref}
     className={cn(
-      "mt-2 inline-flex h-10 items-center justify-center rounded-md border border-slate-200 py-2 px-4 text-sm font-semibold text-overlay-content transition-colors hover:bg-overlay-3 focus:outline-none focus:ring-1 focus:ring-line-focus focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50  sm:mt-0",
+      "inline-flex h-10 items-center justify-center rounded-md border border-slate-200 py-2 px-4 text-sm font-semibold text-overlay-content transition-colors hover:bg-overlay-3 focus:outline-none focus:ring-1 focus:ring-line-focus focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50  sm:mt-0",
       className
     )}
     {...props}


### PR DESCRIPTION
Some extra margin on Alert.Cancel is causing the buttons to be uneven on smaller devices.  
![image](https://user-images.githubusercontent.com/77078215/222501671-b53da22a-d24c-4f3d-b4f8-ffb456f5b90c.png)

I have removed the extra margin from the Alert.Cancel button and added it in the docs preview, to preserve styles instead.